### PR TITLE
Require node verions 6+. Fixes #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "chai-spies": "^0.7.1",
     "jsdoc-to-markdown": "^2.0.1",
     "mocha": "^2.4.5"
+  },
+  "engines": {
+    "node": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Note, npm config setting engine-strict must be enabled for npm install to fail when attempting install with invalid node version.
```npm config set engine-strict true```